### PR TITLE
fix to double-execution of trackLink callback

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -3191,7 +3191,7 @@ if (typeof window.Piwik !== 'object') {
                         if (this.readyState === 4 && !(this.status >= 200 && this.status < 300) && fallbackToGet) {
                             getImage(request, callback);
                         } else {
-                            if (typeof callback === 'function') { callback(); }
+                            if (this.readyState === 4 && (typeof callback === 'function')) { callback(); }
                         }
                     };
 


### PR DESCRIPTION
as reported in issue #10152 : 

in function sendXmlHttpRequest, call to xhr.onreadystatechange, 
callback is executed twice, and actually not when it should.
this is due to this.readyState taking status 2 (the send method has been called), then status 4 (data received complete)
