### PR TITLE
fix to urlnormalizer for supporting custom port

### DIFF
--- a/plugins/Overlay/client/urlnormalizer.js
+++ b/plugins/Overlay/client/urlnormalizer.js
@@ -66,7 +66,7 @@ var Piwik_Overlay_UrlNormalizer = (function () {
     return {
 
         initialize: function () {
-            this.setCurrentDomain(document.location.hostname);
+            this.setCurrentDomain(document.location.host);
             this.setCurrentUrl(window.location.href);
 
             var head = document.getElementsByTagName('head');


### PR DESCRIPTION
as reported in issue #10169 : 

There's no overlay bubbles displayed whatsoever, on site like http://127.0.0.1:81/
This is due to urlnormalizer.js, which removes the port. Then all comparisons with followingpages do fail.

-> smallest fix ever : replace "document.location.hostname" by "document.location.host" , in plugins/Overlay/client/urlnormalizer.js
